### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/ci-devflix.yaml
+++ b/.github/workflows/ci-devflix.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Build & Deploy"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Setup Node"
         uses: actions/setup-node@v4
         with:
@@ -18,7 +18,7 @@ jobs:
           npm install
           NODE_OPTIONS="--max-old-space-size=8192" npm run build
       - name: Upload to S3 Bucket
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311 # master
         with:
           args: --acl public-read --follow-symlinks --delete --exclude='files/*'
         env:
@@ -28,7 +28,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_CRED_SECRET }}
           AWS_REGION: ${{ secrets.CI_REGION }}
       - name: Invalidate Cloudfront - DevFlix Firefly
-        uses: chetan/invalidate-cloudfront-action@master
+        uses: chetan/invalidate-cloudfront-action@fce6f6f546fae2e9fe55f3bd1411063a908f2557 # master
         env:
           PATHS: '/*'
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_CRED_KEY }}
@@ -36,7 +36,7 @@ jobs:
           AWS_REGION: ${{ secrets.CI_REGION }}
           DISTRIBUTION: ${{ secrets.CI_CLOUDFRONT_DISTRIBUTION_ID }}
       - name: Invalidate Cloudfront - DevFlix Co
-        uses: chetan/invalidate-cloudfront-action@master
+        uses: chetan/invalidate-cloudfront-action@fce6f6f546fae2e9fe55f3bd1411063a908f2557 # master
         env:
           PATHS: '/*'
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_CRED_KEY }}


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.